### PR TITLE
Update Go to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/telco-bot
 
-go 1.25.1
+go 1.25.3
 
 require github.com/slack-go/slack v0.17.3
 


### PR DESCRIPTION
This PR updates the Go version to 1.25.4.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3310