### PR TITLE
Update table when in read-only mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,15 @@ format:
 	@echo "Formatting shell scripts in scripts folder..."
 	shfmt -w scripts
 
+.PHONY: fix-lint
+fix-lint: format
+	@echo "Linting fixes applied!"
+
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  lint   - Check shell script formatting (same as CI)"
-	@echo "  format - Fix shell script formatting"
-	@echo "  help   - Show this help message"
+	@echo "  lint     - Check shell script formatting (same as CI)"
+	@echo "  format   - Fix shell script formatting"
+	@echo "  fix-lint - Fix shell script formatting (alias for format)"
+	@echo "  help     - Show this help message"
 


### PR DESCRIPTION
This pull request enhances the `go-version-checker.sh` script with improved error handling and better integration with GitHub issues. The most important changes are the addition of a clear error message when GitHub is unreachable and the automation of checking for existing "Update Go version" issues, updating the tracking file accordingly.

**Error handling improvements:**

* The script now checks if both Kubernetes version fetches fail and, if so, prints a detailed error message explaining possible causes (like GitHub outages or connectivity issues) and exits early.

**GitHub issue integration enhancements:**

* Before creating new issues, the script now automatically checks each outdated repository for existing "Update Go version" issues (open or closed) using the GitHub CLI, and updates the tracking file (`ORG_DATA_FILE`) with any found issue numbers.
* The script's messaging is updated to clarify that it may create or update GitHub issues for outdated repositories, reflecting the new logic.