### PR TITLE
Exclude vendor from search for ioutil

### DIFF
--- a/scripts/ioutil-deprecation-checker.sh
+++ b/scripts/ioutil-deprecation-checker.sh
@@ -327,9 +327,9 @@ check_ioutil_usage() {
 	fi
 
 	# Use GitHub's code search API to look for io/ioutil imports
-	# Search for: "io/ioutil" in Go files
+	# Search for: "io/ioutil" in Go files (excluding vendor directories)
 	# Note: Code Search API has strict rate limits (10 requests/min for authenticated users)
-	local search_result=$(gh api "search/code?q=io/ioutil+repo:${repo}+language:go" 2>&1)
+	local search_result=$(gh api "search/code?q=io/ioutil+repo:${repo}+language:go+-path:vendor" 2>&1)
 	local api_status=$?
 
 	# Check if we got a rate limit error


### PR DESCRIPTION
This pull request makes a targeted improvement to the `scripts/ioutil-deprecation-checker.sh` script. The change updates the GitHub code search query to exclude `vendor` directories when searching for `io/ioutil` imports in Go files, which helps reduce false positives and focuses the check on relevant code.

- Search query improvement:
  * Updated the GitHub code search API query to exclude `vendor` directories when searching for `io/ioutil` imports in Go files, ensuring more accurate results.