### PR TITLE
Bump Go version to 1.26.1 to fix workflow failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/telco-bot
 
-go 1.26.0
+go 1.26.1
 
 require github.com/slack-go/slack v0.18.0
 


### PR DESCRIPTION
## Summary

- Bump Go version from 1.26.0 to 1.26.1 in go.mod
- Fixes failing `daily-dci` and `quay-query` workflows
- External repos (`go-dci` and `go-quay`) require Go >= 1.26.1

## Test plan

- [ ] Verify `daily-dci` workflow succeeds with Go 1.26.1
- [ ] Verify `quay-query` workflow succeeds with Go 1.26.1