### PR TITLE
Set GOTOOLCHAIN=auto for external Go project builds in workflows

### DIFF
--- a/.github/workflows/daily-dci.yml
+++ b/.github/workflows/daily-dci.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Build the go-dci project
         run: go build
         working-directory: go-dci
+        env:
+          GOTOOLCHAIN: auto
 
       - name: Set the config file via the go-dci project
         run: ./go-dci config set --accesskey=${{ secrets.DCI_ACCESS_KEY }} --secretkey=${{ secrets.DCI_SECRET_KEY }}

--- a/.github/workflows/quay-query.yml
+++ b/.github/workflows/quay-query.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Build the go-quay project
         run: go build
         working-directory: go-quay
+        env:
+          GOTOOLCHAIN: auto
 
       - name: Run the go-quay project to gather the last 7 days of Quay statistics
         run: |


### PR DESCRIPTION
## Summary
- Sets `GOTOOLCHAIN=auto` on the `go build` steps for go-dci and go-quay in the daily-dci and quay-query workflows
- Allows Go to auto-download the required toolchain when external projects require a newer Go version
- Decouples Go version bumps between telco-bot and its downstream dependencies (go-dci, go-quay)

## Context
`actions/setup-go` sets `GOTOOLCHAIN=local` when using `go-version-file`, which prevents Go from auto-downloading a newer toolchain. When go-dci or go-quay bump their Go version independently, the build fails. `GOTOOLCHAIN=auto` overrides this for just the external build steps.

## Test plan
- [ ] CI passes
- [ ] Manually trigger daily-dci workflow to verify it succeeds