### PR TITLE
Upgrade Slack notifications to Block Kit and fix Jira workflow

### DIFF
--- a/.github/workflows/jira-team-update.yml
+++ b/.github/workflows/jira-team-update.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           repository: 'sebrandon1/jiracrawler'
           path: jiracrawler
-          ref: v0.0.3
+          ref: v0.0.22
 
       - name: Build the jiracrawler project
         run: make build
@@ -48,7 +48,14 @@ jobs:
         run: ./jiracrawler get assignedissues ${USERS} --projectID ${PROJECT_ID} -o json > ${GITHUB_WORKSPACE}/jira-output-raw.json
         working-directory: jiracrawler
 
-      # This santiizes the raw JSON output from essentially the entire API response into a readable format
+      - name: Validate jiracrawler output is valid JSON
+        run: |
+          if ! jq empty ${GITHUB_WORKSPACE}/jira-output-raw.json 2>/dev/null; then
+            echo "ERROR: jiracrawler produced invalid JSON output:"
+            head -5 ${GITHUB_WORKSPACE}/jira-output-raw.json
+            exit 1
+          fi
+
       - name: Translate the JSON output into a sanitized format
         run: ./scripts/sanitize-raw-jira-format.sh ${GITHUB_WORKSPACE}/jira-output-raw.json ${GITHUB_WORKSPACE}/jira-output.json
 

--- a/scripts/lib/slack.sh
+++ b/scripts/lib/slack.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#===============================================================================
+# SLACK NOTIFICATION LIBRARY FOR TELCO-BOT
+#===============================================================================
+#
+# Shared functions for building and sending Slack messages via Workflow webhooks.
+# Source this file from notification scripts:
+#
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/slack.sh"
+#
+# Requires: curl, jq
+#===============================================================================
+
+# Send a plain text message to a Slack Workflow webhook.
+# Usage: send_slack_message "$WEBHOOK_URL" "$MESSAGE" ["message"|"text"]
+# The third argument is the JSON field name (defaults to "message").
+send_slack_message() {
+	local webhook_url="$1"
+	local message="$2"
+	local field_name="${3:-message}"
+
+	local payload
+	payload=$(jq -n --arg msg "$message" --arg field "$field_name" '{($field): $msg}')
+
+	local response http_code response_body
+	response=$(curl -s -w "\n%{http_code}" -X POST -H 'Content-type: application/json' --data "$payload" "$webhook_url")
+	http_code=$(echo "$response" | tail -n1)
+	response_body=$(echo "$response" | sed '$d')
+
+	if [ "$http_code" = "200" ]; then
+		echo "Slack message sent successfully"
+		return 0
+	else
+		echo "ERROR: Slack send failed (HTTP $http_code): $response_body" >&2
+		return 1
+	fi
+}
+
+# Validate that a file contains valid JSON
+validate_json() {
+	local file="$1"
+	if ! jq empty "$file" 2>/dev/null; then
+		echo "ERROR: Invalid JSON in $file" >&2
+		return 1
+	fi
+}

--- a/scripts/quay-stats-msg.sh
+++ b/scripts/quay-stats-msg.sh
@@ -1,28 +1,18 @@
 #!/bin/bash
 
-# Function to validate required tools
-dependencies_check() {
-	for cmd in jq curl; do
-		if ! command -v $cmd &>/dev/null; then
-			echo "$cmd is required but not installed. Exiting."
-			exit 1
-		fi
-	done
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/slack.sh"
 
-# Function to calculate the total count of jobs with 'kind: pull_repo'
 calculate_pull_repo_jobs() {
 	local json_file=$1
 	jq '.aggregated[] | select(.kind == "pull_repo") | .count' "$json_file" | awk '{s+=$1} END {print s}'
 }
 
-# Validate arguments
 if [ "$#" -lt 7 ]; then
 	echo "Usage: $0 <SLACK_WEBHOOK_URL> <JSON_FILE_LEGACY> <JSON_FILE_CURRENT> <START_DATE> <END_DATE> <REPO_NAME_LEGACY> <REPO_NAME_CURRENT>"
 	exit 1
 fi
 
-# Collect the arguments
 SLACK_WEBHOOK_URL=$1
 JSON_FILE_LEGACY=$2
 JSON_FILE_CURRENT=$3
@@ -31,20 +21,30 @@ END_DATE=$5
 REPO_NAME_LEGACY=$6
 REPO_NAME_CURRENT=$7
 
-# Check dependencies
-dependencies_check
+validate_json "$JSON_FILE_LEGACY" || exit 1
+validate_json "$JSON_FILE_CURRENT" || exit 1
 
-# Calculate the number of pull_repo jobs
 NUMBER_OF_PULL_REPO_JOBS_LEGACY=$(calculate_pull_repo_jobs "$JSON_FILE_LEGACY")
 NUMBER_OF_PULL_REPO_JOBS_CURRENT=$(calculate_pull_repo_jobs "$JSON_FILE_CURRENT")
+TOTAL_PULL_REPO_JOBS=$((NUMBER_OF_PULL_REPO_JOBS_LEGACY + NUMBER_OF_PULL_REPO_JOBS_CURRENT))
 
-TOTAL_PULL_REPO_JOBS=$(($NUMBER_OF_PULL_REPO_JOBS_LEGACY + $NUMBER_OF_PULL_REPO_JOBS_CURRENT))
+if [ "$TOTAL_PULL_REPO_JOBS" -gt 0 ]; then
+	MIGRATION_PCT=$(awk "BEGIN {printf \"%.0f\", ($NUMBER_OF_PULL_REPO_JOBS_CURRENT / $TOTAL_PULL_REPO_JOBS) * 100}")
+else
+	MIGRATION_PCT=0
+fi
 
-MESSAGE="The following images have been pulled $TOTAL_PULL_REPO_JOBS times between $START_DATE and $END_DATE:
+TOTAL_FORMATTED=$(printf "%'d" "$TOTAL_PULL_REPO_JOBS")
 
-$REPO_NAME_LEGACY: $NUMBER_OF_PULL_REPO_JOBS_LEGACY
-$REPO_NAME_CURRENT: $NUMBER_OF_PULL_REPO_JOBS_CURRENT"
+MESSAGE=":package: Certsuite Quay Pull Report
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-# Send the message to Slack
-DATA=$(jq -n --arg message "$MESSAGE" '{message: $message}')
-curl -X POST -H 'Content-type: application/json' --data "$DATA" "$SLACK_WEBHOOK_URL"
+:calendar: Period: ${START_DATE} — ${END_DATE}
+:arrow_down: Total Pulls: ${TOTAL_FORMATTED}
+
+   ${REPO_NAME_CURRENT}: ${NUMBER_OF_PULL_REPO_JOBS_CURRENT}
+   ${REPO_NAME_LEGACY}: ${NUMBER_OF_PULL_REPO_JOBS_LEGACY}
+
+:chart_with_upwards_trend: Migration Progress: ${MIGRATION_PCT}% on current repo"
+
+send_slack_message "$SLACK_WEBHOOK_URL" "$MESSAGE"

--- a/scripts/sanitize-raw-jira-format.sh
+++ b/scripts/sanitize-raw-jira-format.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/slack.sh"
+
 if [[ $# -ne 2 ]]; then
 	echo "Usage: $0 <input_json_file> <output_json_file>"
 	exit 1
@@ -12,6 +15,8 @@ fi
 
 INPUT_FILE="$1"
 OUTPUT_FILE="$2"
+
+validate_json "$INPUT_FILE" || exit 1
 
 jq -r '[.[] | .issues[] 
   | select(.fields.assignee != null) 

--- a/scripts/send-cnf-team-jira-update.sh
+++ b/scripts/send-cnf-team-jira-update.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# Usage: ./send-cnf-team-jira-update.sh <slack_webhook_url> <json_file>
-# Requires: jq, curl
-
-set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/slack.sh"
 
 if [[ $# -lt 2 ]]; then
 	echo "Usage: $0 <slack_webhook_url> <json_file>"
@@ -13,35 +11,35 @@ fi
 SLACK_WEBHOOK_URL="$1"
 JSON_FILE="$2"
 
-# Build the Slack message content
-MESSAGE=$(jq -r '
-  def fixver_counts:
-    [ .[] | .issues[] | {fixVersion} ]
-    | group_by(.fixVersion)
-    | map({fixVersion: .[0].fixVersion, count: length});
+validate_json "$JSON_FILE" || exit 1
 
-  def fixver_summary:
-    fixver_counts
-    | map("- " + (if .fixVersion == "none" then "No Fix Version" else .fixVersion end) + ": " + (.count | tostring) + " issues")
-    | join("\n");
+TOTAL_ISSUES=$(jq '[.[] | .issues | length] | add // 0' "$JSON_FILE")
+MEMBER_COUNT=$(jq 'length' "$JSON_FILE")
 
-  ([ .[] |
-    (.user + " (" + ((.issues | length | tostring)) + " issues assigned):\n") +
-    (
-      if ((.issues // []) | type) != "array" or ((.issues // []) | length) == 0 then
-        "  - No issues"
-      else
-        (.issues | map(
-          .url + " (" + (if .fixVersion == "none" then "No Fix Version" else .fixVersion end) + ") - Status: " + .status + " - Last Updated: " + (.updated | split("T")[0])
-        ) | join("\n"))
-      end
-    )
-  ] | join("\n")) +
-  "\n\nTeam Issue Totals by Fix Version:\n" + fixver_summary
+FIXVER_SUMMARY=$(jq -r '
+  [.[] | .issues[]] | group_by(.fixVersion)
+  | map({v: .[0].fixVersion, c: length})
+  | sort_by(.c) | reverse
+  | map("   " + (if .v == "none" then "No Fix Version" else .v end) + ": " + (.c | tostring) + " issues")
+  | join("\n")
 ' "$JSON_FILE")
 
-# Construct the Slack payload for Workflow webhooks (text only)
-payload=$(jq -n --arg text "$MESSAGE" '{text: $text}')
+USER_SECTIONS=$(jq -r '.[] |
+  ":bust_in_silhouette: " + .user + " (" + (.issues | length | tostring) + " issues):\n" +
+  (.issues | sort_by(.updated) | map(
+    "   " + .url + " (" + (if .fixVersion == "none" then "No Fix Version" else .fixVersion end) + ") — " + .status + " — Updated: " + (.updated | split("T")[0])
+  ) | join("\n")) + "\n"
+' "$JSON_FILE")
 
-# Send to Slack
-curl -s -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+MESSAGE=":clipboard: CNF Team Jira Weekly Update
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+:busts_in_silhouette: Team Members: ${MEMBER_COUNT}
+:ticket: Open Issues: ${TOTAL_ISSUES}
+
+:bar_chart: Issues by Fix Version:
+${FIXVER_SUMMARY}
+
+${USER_SECTIONS}"
+
+send_slack_message "$SLACK_WEBHOOK_URL" "$MESSAGE" "text"

--- a/scripts/send-slack-msg.sh
+++ b/scripts/send-slack-msg.sh
@@ -1,91 +1,75 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/slack.sh"
+
 SEMVER_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+$"
 
-# Function to validate required tools
-dependencies_check() {
-	for cmd in jq curl; do
-		if ! command -v $cmd &>/dev/null; then
-			echo "$cmd is required but not installed. Exiting."
-			exit 1
-		fi
-	done
-}
-
-# Function to decode base64 and extract JSON fields
 _jq() {
 	echo "${1}" | base64 --decode | jq -r "${2}"
 }
 
-# Validate arguments
 if [ "$#" -lt 4 ]; then
 	echo "Usage: $0 <SLACK_WEBHOOK_URL> <JSON_FILE> <OCP_VERSION_FILE> <DAYS_BACK>"
 	exit 1
 fi
 
-# Collect the arguments
 SLACK_WEBHOOK_URL=$1
 JSON_FILE=$2
 OCP_VERSION_FILE=$3
 DAYS_BACK=$4
 
-# Check dependencies
-dependencies_check
+validate_json "$JSON_FILE" || exit 1
+validate_json "$OCP_VERSION_FILE" || exit 1
 
 NUMBER_OF_RECORDS=$(jq '.jobs | length' "$JSON_FILE")
-
 RUNS_BY_COMMIT_CTR=0
 
-MESSAGE="There have been $NUMBER_OF_RECORDS DCI jobs that have used the certsuite in the last $DAYS_BACK days.
-"
+VERSIONS_BY_VALUE=$(jq '.jobs | group_by(.certsuite_version) | map({key: .[0].certsuite_version, value: length}) | sort_by(.key) | reverse' "$JSON_FILE")
 
-VERSIONS_BY_VALUE=$(jq '.jobs | group_by(.certsuite_version) | map({key: .[0].certsuite_version, value: length})' "$JSON_FILE")
-
+VERSION_LINES=""
 for row in $(echo "$VERSIONS_BY_VALUE" | jq -r '.[] | @base64'); do
-	# Check if the version matches the semver regex
 	if [[ ! $(_jq "$row" '.key') =~ $SEMVER_REGEX ]]; then
-		let "RUNS_BY_COMMIT_CTR=RUNS_BY_COMMIT_CTR+$(_jq "$row" '.value')"
+		RUNS_BY_COMMIT_CTR=$((RUNS_BY_COMMIT_CTR + $(_jq "$row" '.value')))
 	else
 		VERSION=$(_jq "$row" '.key')
 		COUNT=$(_jq "$row" '.value')
-
-		MESSAGE="$MESSAGE
- Version: $VERSION -- Run Count: $COUNT"
+		VERSION_LINES="${VERSION_LINES}   ${VERSION}  —  ${COUNT} runs
+"
 	fi
 done
 
-if [ $RUNS_BY_COMMIT_CTR -gt 0 ]; then
-	MESSAGE="$MESSAGE
-
-There have been $RUNS_BY_COMMIT_CTR runs by commit hash."
-fi
-
-# Use jq to verify OCP_VERSION_FILE is valid JSON
-if ! jq . "$OCP_VERSION_FILE" &>/dev/null; then
-	echo "The OCP_VERSION_FILE is not valid JSON. Exiting."
-	exit 1
-fi
-
-MESSAGE="$MESSAGE
-
-The following OCP versions have been tested against in the last $DAYS_BACK days:"
-
+OCP_LINES=""
 for row in $(jq -r '.ocp_versions[] | @base64' "$OCP_VERSION_FILE"); do
-	# Skip any counts that are 0
-	if [ $(_jq "$row" '.run_count') -eq 0 ]; then
+	if [ "$(_jq "$row" '.run_count')" -eq 0 ]; then
 		continue
 	fi
-
 	VERSION=$(_jq "$row" '.ocp_version')
 	COUNT=$(_jq "$row" '.run_count')
-
-	MESSAGE="$MESSAGE
-OCP Version: $VERSION -- Run Count: $COUNT"
+	OCP_LINES="${OCP_LINES}   ${VERSION}  —  ${COUNT} runs
+"
 done
 
+MESSAGE=":bar_chart: Certsuite DCI Weekly Report
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+:hash: ${NUMBER_OF_RECORDS} DCI jobs used the certsuite in the last ${DAYS_BACK} days
+"
+
+if [ -n "$VERSION_LINES" ]; then
+	MESSAGE="${MESSAGE}
+:package: Runs by Release Version:
+${VERSION_LINES}"
+fi
+
+if [ $RUNS_BY_COMMIT_CTR -gt 0 ]; then
+	MESSAGE="${MESSAGE}:wrench: ${RUNS_BY_COMMIT_CTR} runs by commit hash
+"
+fi
+
+MESSAGE="${MESSAGE}
+:desktop_computer: OCP Versions Tested:
+${OCP_LINES}"
+
 echo "$MESSAGE"
-
-DATA=$(jq -n --arg message "$MESSAGE" '{message: $message}')
-
-# Send the message to Slack
-curl -X POST -H 'Content-type: application/json; charset=UTF-8' --data "$DATA" "$SLACK_WEBHOOK_URL"
+send_slack_message "$SLACK_WEBHOOK_URL" "$MESSAGE"

--- a/scripts/xcrypto-slack.sh
+++ b/scripts/xcrypto-slack.sh
@@ -1,142 +1,64 @@
 #!/bin/bash
 
-#===============================================================================
-# XCRYPTO SLACK NOTIFICATION SCRIPT
-#===============================================================================
-#
-# DESCRIPTION:
-#   Sends a Slack notification with x/crypto scan results.
-#   Can be run standalone for testing or called from xcrypto-lookup.sh.
-#
-# PREREQUISITES:
-#   1. curl and jq must be installed
-#   2. XCRYPTO_SLACK_WEBHOOK environment variable must be set
-#
-# USAGE:
-#   # Set required environment variable
-#   export XCRYPTO_SLACK_WEBHOOK="https://hooks.slack.com/triggers/..."
-#
-#   # Run with arguments
-#   ./xcrypto-slack.sh <total_repos> <org_count> <outdated_count> <found_count> <tracking_issue_url>
-#
-#   # Example:
-#   ./xcrypto-slack.sh 500 5 12 25 "https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/42"
-#
-# TESTING LOCALLY:
-#   export XCRYPTO_SLACK_WEBHOOK="your-webhook-url"
-#   ./scripts/xcrypto-slack.sh 100 3 5 10 "https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/1"
-#
-#===============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/lib/slack.sh"
 
-# Terminal colors
-GREEN="\033[0;32m"
-RED="\033[0;31m"
-BLUE="\033[0;34m"
-YELLOW="\033[0;33m"
-BOLD="\033[1m"
-RESET="\033[0m"
-
-# Check if XCRYPTO_SLACK_WEBHOOK is set
 if [ -z "$XCRYPTO_SLACK_WEBHOOK" ]; then
-	echo -e "${YELLOW}⚠️  XCRYPTO_SLACK_WEBHOOK not set, skipping Slack notification${RESET}"
+	echo -e "${YELLOW}XCRYPTO_SLACK_WEBHOOK not set, skipping Slack notification${RESET}"
 	exit 0
 fi
 
-# Check dependencies
-for cmd in curl jq; do
-	if ! command -v $cmd &>/dev/null; then
-		echo -e "${RED}❌ ERROR: $cmd is required but not installed${RESET}"
-		exit 1
-	fi
-done
-
-# Validate arguments
 if [ "$#" -lt 5 ]; then
-	echo -e "${RED}❌ ERROR: Missing required arguments${RESET}"
+	echo -e "${RED}ERROR: Missing required arguments${RESET}"
 	echo ""
 	echo "Usage: $0 <total_repos> <org_count> <outdated_count> <found_count> <tracking_issue_url>"
-	echo ""
-	echo "Arguments:"
-	echo "  total_repos        - Total number of repositories scanned"
-	echo "  org_count          - Number of organizations scanned"
-	echo "  outdated_count     - Number of repos with outdated x/crypto versions"
-	echo "  found_count        - Number of repos using x/crypto directly"
-	echo "  tracking_issue_url - URL to the tracking issue"
-	echo ""
-	echo "Example:"
-	echo "  $0 500 5 12 25 \"https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/42\""
 	exit 1
 fi
 
-# Collect arguments
 TOTAL_REPOS="$1"
 ORG_COUNT="$2"
 OUTDATED_COUNT="$3"
 FOUND_COUNT="$4"
 TRACKING_ISSUE_URL="$5"
 
-echo -e "${BLUE}${BOLD}📤 Sending Slack Notification${RESET}"
-echo -e "${BLUE}─────────────────────────────────────────────────────${RESET}"
+echo -e "${BLUE}${BOLD}Sending Slack Notification${RESET}"
 echo -e "   Total repos scanned: ${TOTAL_REPOS}"
 echo -e "   Organizations: ${ORG_COUNT}"
 echo -e "   Repos using x/crypto: ${FOUND_COUNT}"
 echo -e "   Outdated repos: ${OUTDATED_COUNT}"
 echo -e "   Tracking issue: ${TRACKING_ISSUE_URL}"
-echo
 
-# Build the message (plain text - Slack Workflow webhooks don't support mrkdwn)
-# Customize message based on outdated count
-if [ "$OUTDATED_COUNT" -eq 0 ]; then
-	# All repos are up to date! 🎉
-	MESSAGE="🔐 x/crypto Weekly Scan Complete ✅
-
-🔍 Scanned ${TOTAL_REPOS} repositories across ${ORG_COUNT} organizations
-
-🎉 Great news! All ${FOUND_COUNT} repos using x/crypto are up to date. No action needed!
-
-📋 Full report: ${TRACKING_ISSUE_URL}"
-elif [ "$OUTDATED_COUNT" -lt 5 ]; then
-	# Small number of outdated repos
-	MESSAGE="🔐 x/crypto Weekly Scan Complete
-
-🔍 Scanned ${TOTAL_REPOS} repositories across ${ORG_COUNT} organizations
-
-⚠️ ${OUTDATED_COUNT} repos need attention — they're running outdated versions of x/crypto and should be updated for security.
-
-📋 View the full breakdown: ${TRACKING_ISSUE_URL}"
+if [ "$FOUND_COUNT" -gt 0 ]; then
+	OUTDATED_PCT=$(awk "BEGIN {printf \"%.0f\", ($OUTDATED_COUNT / $FOUND_COUNT) * 100}")
 else
-	# Larger number of outdated repos - more urgent tone
-	MESSAGE="🔐 x/crypto Weekly Scan Complete
-
-🔍 Scanned ${TOTAL_REPOS} repositories across ${ORG_COUNT} organizations
-
-🚨 ${OUTDATED_COUNT} repos are running outdated versions of x/crypto and need to be updated!
-
-Keeping crypto libraries current is critical for security. Please review and prioritize updates.
-
-📋 Tracking issue: ${TRACKING_ISSUE_URL}"
+	OUTDATED_PCT=0
 fi
 
-# Construct Slack payload with 'message' field (matching webhook config)
-PAYLOAD=$(jq -n --arg message "$MESSAGE" '{message: $message}')
-
-echo -e "   ${BLUE}Message:${RESET}"
-echo -e "   $MESSAGE"
-echo
-
-# Send to Slack
-echo -ne "   Sending to Slack... "
-RESPONSE=$(curl -s -w "\n%{http_code}" -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$XCRYPTO_SLACK_WEBHOOK")
-
-# Extract HTTP status code (last line) and response body
-HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
-
-if [ "$HTTP_CODE" = "200" ]; then
-	echo -e "${GREEN}✅ Success${RESET}"
-	echo -e "${GREEN}${BOLD}✅ Slack notification sent successfully!${RESET}"
+if [ "$OUTDATED_COUNT" -eq 0 ]; then
+	STATUS_LINE=":white_check_mark: All ${FOUND_COUNT} repos using x/crypto are up to date! No action needed."
+elif [ "$OUTDATED_COUNT" -lt 5 ]; then
+	STATUS_LINE=":warning: ${OUTDATED_COUNT} repos need attention — running outdated versions of x/crypto (${OUTDATED_PCT}% of users)"
 else
-	echo -e "${RED}❌ Failed (HTTP $HTTP_CODE)${RESET}"
-	echo -e "${RED}   Response: $RESPONSE_BODY${RESET}"
+	STATUS_LINE=":rotating_light: ${OUTDATED_COUNT} repos are running outdated x/crypto versions! (${OUTDATED_PCT}% of users)
+
+Keeping crypto libraries current is critical for security. Please review and prioritize updates."
+fi
+
+MESSAGE=":lock: x/crypto Weekly Security Scan
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+:mag: Scanned ${TOTAL_REPOS} repositories across ${ORG_COUNT} organizations
+:package: ${FOUND_COUNT} repos using x/crypto directly
+
+${STATUS_LINE}
+
+:page_facing_up: Full report: ${TRACKING_ISSUE_URL}"
+
+echo
+if send_slack_message "$XCRYPTO_SLACK_WEBHOOK" "$MESSAGE"; then
+	echo -e "${GREEN}${BOLD}Slack notification sent successfully!${RESET}"
+else
+	echo -e "${RED}${BOLD}Failed to send Slack notification${RESET}"
 	exit 1
 fi


### PR DESCRIPTION
## Summary
- **Fix broken Jira workflow**: Bump jiracrawler v0.0.3 → v0.0.22 and add JSON validation before sanitization to prevent `jq: parse error` failures
- **Improve all 4 notification scripts**: Add emoji, Unicode separators, better structure, and new metrics while keeping existing Workflow webhook format
- **Create shared `scripts/lib/slack.sh` library**: Reusable `send_slack_message` (with HTTP error handling) and `validate_json` functions
- **Add new metrics**: Migration percentage in Quay report, outdated percentage in x/crypto report

No webhook or secret changes required — all scripts continue to use existing Workflow webhooks.

## Test plan
- [ ] Verify `make lint` passes (shfmt)
- [ ] Trigger each workflow via `workflow_dispatch` and verify Slack output
- [ ] Verify Jira workflow completes successfully with jiracrawler v0.0.22