### PR TITLE
ci: pin ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/daily-dci.yml
+++ b/.github/workflows/daily-dci.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   weekly-query:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
       NUM_DAYS: 7

--- a/.github/workflows/go-version-checker-daily.yml
+++ b/.github/workflows/go-version-checker-daily.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   check-go-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/golangci-lint-checker-daily.yml
+++ b/.github/workflows/golangci-lint-checker-daily.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   check-golangci-lint-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/gomock-checker-daily.yml
+++ b/.github/workflows/gomock-checker-daily.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   check-gomock-usage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ioutil-deprecation-checker-daily.yml
+++ b/.github/workflows/ioutil-deprecation-checker-daily.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   check-ioutil-usage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -7,7 +7,7 @@ on:
 permissions: read-all
 jobs:
   shfmt-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/quay-query.yml
+++ b/.github/workflows/quay-query.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   quay-query:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
       REPO_NAME_LEGACY: cnf-certification-test

--- a/.github/workflows/tls13-compliance-checker-weekly.yml
+++ b/.github/workflows/tls13-compliance-checker-weekly.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   tls-compliance-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
 

--- a/.github/workflows/update-caches-daily.yml
+++ b/.github/workflows/update-caches-daily.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   update-caches:
     if: github.repository_owner == 'redhat-best-practices-for-k8s'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/xcrypto-lookup.yml
+++ b/.github/workflows/xcrypto-lookup.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 jobs:
   xcrypto-lookup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SHELL: /bin/bash
 


### PR DESCRIPTION
## Summary
- Pin `ubuntu-latest` to `ubuntu-24.04` in all GitHub Actions workflows

Prevents unexpected behavior changes when GitHub updates the `ubuntu-latest` label.
Tracked by [CNFCERT-1419](https://redhat.atlassian.net/browse/CNFCERT-1419).