### PR TITLE
fix: update go-quay CLI command for Quay stats workflow

### DIFF
--- a/.github/workflows/quay-query.yml
+++ b/.github/workflows/quay-query.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: 'sebrandon1/go-quay'
+          ref: 'v1.0.6'
           path: go-quay
 
       - name: Build the go-quay project

--- a/.github/workflows/quay-query.yml
+++ b/.github/workflows/quay-query.yml
@@ -51,12 +51,12 @@ jobs:
           echo "7 days ago: ${SEVEN_DAYS_AGO}"
           echo "---------------------------------"
           echo "Querying the legacy repository: ${NS_NAME_LEGACY}/${REPO_NAME_LEGACY}"
-          RESULT=$(./go-quay get aggregatedlogs -t ${{ secrets.QUAY_TOKEN_LEGACY }} -n ${NS_NAME_LEGACY} -r ${REPO_NAME_LEGACY} -s ${SEVEN_DAYS_AGO} -e ${TODAY})
+          RESULT=$(./go-quay get logs repo-aggregated-logs -t ${{ secrets.QUAY_TOKEN_LEGACY }} -n ${NS_NAME_LEGACY} -r ${REPO_NAME_LEGACY} -s ${SEVEN_DAYS_AGO} -e ${TODAY})
           echo "Result of the legacy repository query: ${RESULT}"
           echo "${RESULT}" > ${GITHUB_WORKSPACE}/quay-output-legacy.json
 
           echo "Querying the current repository: ${NS_NAME_CURRENT}/${REPO_NAME_CURRENT}"
-          RESULT=$(./go-quay get aggregatedlogs -t ${{ secrets.QUAY_TOKEN }} -n ${NS_NAME_CURRENT} -r ${REPO_NAME_CURRENT} -s ${SEVEN_DAYS_AGO} -e ${TODAY}) 
+          RESULT=$(./go-quay get logs repo-aggregated-logs -t ${{ secrets.QUAY_TOKEN }} -n ${NS_NAME_CURRENT} -r ${REPO_NAME_CURRENT} -s ${SEVEN_DAYS_AGO} -e ${TODAY}) 
           echo "Result of the current repository query: ${RESULT}"
           echo "${RESULT}" > ${GITHUB_WORKSPACE}/quay-output.json
         working-directory: go-quay


### PR DESCRIPTION
## Summary

- The upstream `go-quay` CLI restructured its command hierarchy — `get aggregatedlogs` was replaced by `get logs repo-aggregated-logs`
- The workflow was calling the old command, which errored with `unknown shorthand flag: 'n' in -n` and produced empty output
- This caused the weekly Slack report to show 0 pulls for both certsuite images

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` after merge
- [ ] Verify CI logs show valid JSON responses from `go-quay`
- [ ] Confirm Slack message reports non-zero pull counts