### PR TITLE
docs: add TLS 1.3 checker, fix make targets, update script table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ The codebase is primarily shell scripts with a minimal Go-based Slack bot framew
 ```bash
 make lint      # Check shell script formatting with shfmt
 make format    # Auto-fix shell script formatting
+make fix-lint  # Alias for format
+make help      # Show all available targets
 ```
 
 ### Running Scans
@@ -55,6 +57,10 @@ All scripts in `scripts/` support `--help`:
 - `ubi-lookup.sh` - Finds specific UBI image versions in Dockerfiles
 - `find-downstream-repos.sh` - Identifies forks and mirrors
 
+**TLS 1.3 Compliance** (`scripts/`):
+- `tls13-compliance-checker.sh` - Multi-language TLS compliance scanner (Go, Python, Node.js, C++). Detects disabled certificate verification, weak TLS versions (1.0/1.1), and hardcoded TLS config not using centralized `tlsSecurityProfile`. Uses local clones for rate-limit-free scanning. Binary PASS/FAIL model aligned with CNF-21745.
+- Config: `tls13-compliance-checker-repo-list.txt` (repos to include), `tls13-repo-blocklist.txt` (repos to exclude)
+
 **Cache Management** (`scripts/`):
 - `update-caches.sh` - Comprehensive cache updater
 - `update-fork-cache.sh` - Updates fork repository cache
@@ -65,6 +71,10 @@ All scripts in `scripts/` support `--help`:
 - `quay-stats-msg.sh` - Quay.io pull statistics to Slack
 - `send-cnf-team-jira-update.sh` - Jira updates to Slack
 - `xcrypto-slack.sh` - x/crypto scan results to Slack
+
+**Shared Libraries** (`scripts/lib/`):
+- `common.sh` - Shared constants (terminal colors, default orgs, limits) and utility functions used by all scanner scripts. Source with: `source "$SCRIPT_DIR/lib/common.sh"`
+- `slack.sh` - Slack Workflow webhook functions (`send_slack_message`, `validate_json`). Source with: `source "$SCRIPT_DIR/lib/slack.sh"`
 
 ### Shared Cache System
 
@@ -94,9 +104,10 @@ Located in `.github/workflows/`:
 - `golangci-lint-checker-daily.yml` - Daily linter version scans
 - `gomock-checker-daily.yml` - Daily gomock usage scans
 - `update-caches-daily.yml` - Daily cache updates
-- `xcrypto-lookup-weekly.yml` - Weekly x/crypto scans
+- `xcrypto-lookup.yml` - Daily x/crypto scans
 - `ioutil-deprecation-checker-daily.yml` - Daily io/ioutil scans
-- `daily-dci.yml` / `quay-query.yml` / `jira-team-update.yml` - Notification workflows
+- `tls13-compliance-checker-weekly.yml` - Weekly TLS 1.3 compliance scans (uploads report artifact)
+- `daily-dci.yml` / `quay-query.yml` - Notification workflows
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -70,22 +70,35 @@ All automation scripts are located in the `scripts/` directory. Each script incl
 | `gomock-lookup.sh` | Find repositories using deprecated golang/mock package |
 | `golangci-lint-checker.sh` | Scan for outdated golangci-lint versions across organizations |
 | `xcrypto-lookup.sh` | Identify golang.org/x/crypto usage |
+| `ioutil-deprecation-checker.sh` | Scan for deprecated io/ioutil package usage |
+| `tls13-compliance-checker.sh` | Multi-language TLS 1.3 compliance scanner (Go, Python, Node.js, C++) |
 | `ubi-lookup.sh` | Scan for specific UBI image versions in Dockerfiles |
 | `find-downstream-repos.sh` | Identify downstream forks and mirrors |
 | `update-fork-cache.sh` | Update cache of fork repositories |
 | `update-abandoned-repo-cache.sh` | Find and cache abandoned repositories |
+| `update-caches.sh` | Update all shared caches (forks, abandoned, no-gomod) |
 | `send-slack-msg.sh` | Send DCI certsuite statistics to Slack |
 | `quay-stats-msg.sh` | Send Quay image pull statistics to Slack |
 | `send-cnf-team-jira-update.sh` | Send Jira team updates to Slack |
+| `xcrypto-slack.sh` | Send x/crypto scan results to Slack |
 | `sanitize-raw-jira-format.sh` | Format raw Jira data for processing |
 
 ## Development
 
 The repository includes a basic Go-based Slack bot framework (`main.go`) that can be extended for interactive queries and automated responses.
 
-### Building
+### Makefile Targets
 ```bash
-make build
+make lint                  # Check shell script formatting (same as CI)
+make format                # Fix shell script formatting
+make fix-lint              # Fix shell script formatting (alias for format)
+make run-all-scans         # Run all lookup scans
+make run-xcrypto-scan      # Scan for golang.org/x/crypto direct usage
+make run-gomock-scan       # Scan for deprecated golang/mock usage
+make run-ubi-scan          # Scan for UBI7 image usage
+make run-golangci-lint-scan # Scan for outdated golangci-lint versions
+make run-ioutil-scan       # Scan for deprecated io/ioutil usage
+make help                  # Show all available targets
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary

- Add TLS 1.3 compliance checker documentation to CLAUDE.md (script, weekly workflow, config files)
- Add scripts/lib/ shared libraries section (common.sh, slack.sh)
- Fix workflow name mismatch: `xcrypto-lookup-weekly.yml` -> `xcrypto-lookup.yml` (it runs daily, not weekly)
- Remove non-existent `jira-team-update.yml` workflow reference
- Add `tls13-compliance-checker-weekly.yml` workflow to CI/CD section
- Add missing Makefile targets to CLAUDE.md: `fix-lint`, `help`
- Replace non-existent `make build` in README with full Makefile target listing
- Add 4 missing scripts to README table: `ioutil-deprecation-checker.sh`, `tls13-compliance-checker.sh`, `update-caches.sh`, `xcrypto-slack.sh`